### PR TITLE
Simplify message parse.

### DIFF
--- a/EHubActivityLogs/index.js
+++ b/EHubActivityLogs/index.js
@@ -21,9 +21,7 @@ const parse = require('../common/parse');
 
 var formatActivityLogRecord = function(msg) {
     const ts = parse.getMsgTs(msg);
-    // If properties.eventCategory is not present, category is "Administrative"
-    // https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log-schema#mapping-to-diagnostic-logs-schema
-    const typeId = parse.getMsgTypeId(msg, 'Administrative');
+    const typeId = parse.getMsgTypeId(msg);
     return {
         messageTs: ts.sec,
         priority: 11,
@@ -31,7 +29,7 @@ var formatActivityLogRecord = function(msg) {
         pid: undefined,
         message: JSON.stringify(msg),
         // TODO: detect message type
-        messageType: 'json/azure.activitylog',
+        messageType: 'json/azure.ehub',
         messageTypeId: typeId,
         messageTsUs: ts.usec
     };

--- a/EHubGeneral/index.js
+++ b/EHubGeneral/index.js
@@ -16,7 +16,7 @@ const parse = require('../common/parse');
 
 var formatGeneralLogRecord = function(msg) {
     const ts = parse.getMsgTs(msg);
-    const typeId = parse.getMsgTypeId(msg, null);
+    const typeId = parse.getMsgTypeId(msg);
     return {
         messageTs: ts.sec,
         priority: 11,

--- a/common/parse.js
+++ b/common/parse.js
@@ -3,7 +3,7 @@
  * @doc
  *
  * Message parse utilities common for event hub collector functions.
- * Message timestamp and type proprty paths are based on Azure event schema definitions
+ * Message timestamp and type property paths are based on Azure event schema definitions
  * https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log-schema#mapping-to-diagnostic-logs-schema
  * https://docs.microsoft.com/en-us/azure/azure-monitor/platform/tutorial-dashboards
  *
@@ -11,18 +11,19 @@
  * -----------------------------------------------------------------------------
  */
 
-const typePaths = [
-    ['operationName', 'value'],
-    ['operationName'],
-    ['category', 'value'],
-    ['category'],
-    ['RecordType']
+const typeIdPaths = [
+    { path: ['category', 'value'] },
+    { path: ['category'] },
+    { path: ['operationName', 'value'] },
+    { path: ['operationName'] },
+    { path: ['RecordType'] },
+    { path: ['Operation'] }
 ];
 
 const tsPaths = [
-    ['eventTimestamp'],
-    ['time'],
-    ['CreationTime']
+    { path: ['eventTimestamp'] },
+    { path: ['time'] },
+    { path: ['CreationTime'] }
 ];
 
 /*
@@ -81,7 +82,12 @@ var iteratePropPaths = function(paths, msg) {
         if (acc) {
             return acc;
         } else {
-            return getProp(v, msg);
+            const propVal = getProp(v.path, msg);
+            if (v.override) {
+                return propVal ? v.override : propVal;
+            } else {
+                return propVal;
+            }
         }
     }, null);
 };
@@ -91,12 +97,13 @@ var getMsgTs = function(msg) {
     return msgTs ? parseTs(msgTs) : defaultTs();
 };
 
-var getMsgTypeId = function(msg, defaultVal) {
-    var msgType = iteratePropPaths(typePaths, msg);
+var getMsgTypeId = function(msg, defaultVal = null) {
+    var msgType = iteratePropPaths(typeIdPaths, msg);
     return msgType ? msgType : defaultVal;
 };
 
 module.exports = {
+    iteratePropPaths: iteratePropPaths,
     getMsgTs: getMsgTs,
     getMsgTypeId: getMsgTypeId
 };

--- a/test/ehub_activity_test.js
+++ b/test/ehub_activity_test.js
@@ -23,7 +23,8 @@ describe('Event hub functions unit tests.', function() {
         var privFormatFun = ehubActivityLogsWire.__get__('formatActivityLogRecord');
         var result = privFormatFun(mock.ACTIVITY_LOG_RECORD);
         assert.equal(result.message, JSON.stringify(mock.ACTIVITY_LOG_RECORD));
-        assert.equal(result.messageTypeId, 'Microsoft.Advisor/recommendations/available/action');
+        assert.equal(result.messageType, 'json/azure.ehub');
+        assert.equal(result.messageTypeId, 'Recommendation');
         assert.equal(result.messageTs, 1545207501);
         assert.equal(result.messageTsUs, 183454);
         
@@ -36,7 +37,8 @@ describe('Event hub functions unit tests.', function() {
         testRecord.eventTimestamp = '2018-12-19T08:18:21.13Z';
         var result = privFormatFun(testRecord);
         assert.equal(result.message, JSON.stringify(testRecord));
-        assert.equal(result.messageTypeId, 'Microsoft.Advisor/recommendations/available/action');
+        assert.equal(result.messageType, 'json/azure.ehub');
+        assert.equal(result.messageTypeId, 'Recommendation');
         assert.equal(result.messageTs, 1545207501);
         assert.equal(result.messageTsUs, 130000);
         
@@ -47,34 +49,23 @@ describe('Event hub functions unit tests.', function() {
         var privFormatFun = ehubActivityLogsWire.__get__('formatActivityLogRecord');
         var result = privFormatFun(mock.AUDIT_LOG_RECORD);
         assert.equal(result.message, JSON.stringify(mock.AUDIT_LOG_RECORD));
-        assert.equal(result.messageTypeId, 'Update policy');
+        assert.equal(result.messageType, 'json/azure.ehub');
+        assert.equal(result.messageTypeId, 'AuditLogs');
         assert.equal(result.messageTs, 1544400226);
         assert.equal(result.messageTsUs, 616182);
         
         done();
     });
     
-    it('Default message type (Administrative)', function(done) {
+    it('Default message type id (null)', function(done) {
         var privFormatFun = ehubActivityLogsWire.__get__('formatActivityLogRecord');
         var testRecord = Object.assign({}, mock.AUDIT_LOG_RECORD);
         delete testRecord.category;
         delete testRecord.operationName;
         var result = privFormatFun(testRecord);
         assert.equal(result.message, JSON.stringify(testRecord));
-        assert.equal(result.messageTypeId, 'Administrative');
-        assert.equal(result.messageTs, 1544400226);
-        assert.equal(result.messageTsUs, 616182);
-        
-        done();
-    });
-    
-    it('Category as message type', function(done) {
-        var privFormatFun = ehubActivityLogsWire.__get__('formatActivityLogRecord');
-        var testRecord = Object.assign({}, mock.AUDIT_LOG_RECORD);
-        delete testRecord.operationName;
-        var result = privFormatFun(testRecord);
-        assert.equal(result.message, JSON.stringify(testRecord));
-        assert.equal(result.messageTypeId, 'AuditLogs');
+        assert.equal(result.messageType, 'json/azure.ehub');
+        assert.equal(result.messageTypeId, null);
         assert.equal(result.messageTs, 1544400226);
         assert.equal(result.messageTsUs, 616182);
         

--- a/test/ehub_general_test.js
+++ b/test/ehub_general_test.js
@@ -23,7 +23,8 @@ describe('Event hub functions unit tests.', function() {
         var privFormatFun = ehubGeneralWire.__get__('formatGeneralLogRecord');
         var result = privFormatFun(mock.ACTIVITY_LOG_RECORD);
         assert.equal(result.message, JSON.stringify(mock.ACTIVITY_LOG_RECORD));
-        assert.equal(result.messageTypeId, 'Microsoft.Advisor/recommendations/available/action');
+        assert.equal(result.messageType, 'json/azure.ehub');
+        assert.equal(result.messageTypeId, 'Recommendation');
         assert.equal(result.messageTs, 1545207501);
         assert.equal(result.messageTsUs, 183454);
         
@@ -34,7 +35,24 @@ describe('Event hub functions unit tests.', function() {
         var privFormatFun = ehubGeneralWire.__get__('formatGeneralLogRecord');
         var result = privFormatFun(mock.O365_RECORD);
         assert.equal(result.message, JSON.stringify(mock.O365_RECORD));
+        assert.equal(result.messageType, 'json/azure.ehub');
         assert.equal(result.messageTypeId, '15');
+        assert.equal(result.messageTs, 1521651632);
+        assert.equal(result.messageTsUs, null);
+        
+        done();
+    });
+    
+    it('Simple OK test, other record', function(done) {
+        var privFormatFun = ehubGeneralWire.__get__('formatGeneralLogRecord');
+        var testRecord = {
+             "CreationTime": "2018-03-21T17:00:32",
+             some: 'value'
+        };
+        var result = privFormatFun(testRecord);
+        assert.equal(result.message, JSON.stringify(testRecord));
+        assert.equal(result.messageType, 'json/azure.ehub');
+        assert.equal(result.messageTypeId, null);
         assert.equal(result.messageTs, 1521651632);
         assert.equal(result.messageTsUs, null);
         

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -8,12 +8,14 @@
  * -----------------------------------------------------------------------------
  */
  
-var assert = require('assert');
-var rewire = require('rewire');
-var sinon = require('sinon');
-var mock = require('./mock');
+const assert = require('assert');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const mock = require('./mock');
 
-var parse = rewire('../common/parse');
+var parseWire = rewire('../common/parse');
+
+const parse = require('../common/parse');
 
 describe('Common parse functions unit tests.', function() {
     var clock;
@@ -26,7 +28,7 @@ describe('Common parse functions unit tests.', function() {
     });
     
     it('Simple OK test', function(done) {
-        var privGetProp = parse.__get__('getProp');
+        var privGetProp = parseWire.__get__('getProp');
         var obj = {
             a: {
                 aa: 1,
@@ -43,7 +45,7 @@ describe('Common parse functions unit tests.', function() {
     });
     
     it('Empty path', function(done) {
-        var privGetProp = parse.__get__('getProp');
+        var privGetProp = parseWire.__get__('getProp');
         var obj = {
             a: {
                 aa: 1,
@@ -58,14 +60,14 @@ describe('Common parse functions unit tests.', function() {
     });
     
     it('Empty obj', function(done) {
-        var privGetProp = parse.__get__('getProp');
+        var privGetProp = parseWire.__get__('getProp');
         assert.deepEqual(privGetProp(['a'], {}), null);
         
         done();
     });
     
     it('Wrong path', function(done) {
-        var privGetProp = parse.__get__('getProp');
+        var privGetProp = parseWire.__get__('getProp');
         var obj = {
             a: {
                 aa: 1,
@@ -81,7 +83,7 @@ describe('Common parse functions unit tests.', function() {
     });
     
     it('Ok test with default', function(done) {
-        var privGetProp = parse.__get__('getProp');
+        var privGetProp = parseWire.__get__('getProp');
         var obj = {
             a: {
                 aa: 1,
@@ -97,7 +99,7 @@ describe('Common parse functions unit tests.', function() {
     });
     
     it('Parse timestamp ISO-8601', function(done) {
-        var privParseTs = parse.__get__('parseTs');
+        var privParseTs = parseWire.__get__('parseTs');
         assert.deepEqual(privParseTs('2018-12-19T08:18:21.13Z'), {sec: 1545207501, usec: 130000});
         assert.deepEqual(privParseTs('2018-12-19T08:18:21Z'), {sec: 1545207501, usec: null});
         assert.deepEqual(privParseTs('2018-12-19T08:18:21.1357685Z'), {sec: 1545207501, usec: 135768});
@@ -114,8 +116,23 @@ describe('Common parse functions unit tests.', function() {
     });
     
     it('Wrong timestamp input', function(done) {
-        var privParseTs = parse.__get__('parseTs');
+        var privParseTs = parseWire.__get__('parseTs');
         assert.deepEqual(privParseTs('foo'), {sec: 1234567, usec: null});
+        
+        done();
+    });
+    
+    it('Test override values', function(done) {
+        const testPaths = [
+            { path: ['eventTimestamp'] },
+            { path: ['time'], override: 'foo' },
+            { path: ['CreationTime'] }
+        ];
+        const testObj = {
+            some: 'value',
+            time: 'some-time'
+        };
+        assert.deepEqual(parse.iteratePropPaths(testPaths, testObj), 'foo');
         
         done();
     });


### PR DESCRIPTION
Always use `json/azure.ehub` as a message type. Put detected message type into messageTypeId. Keep it simple.
Add `override` behavior to message parsing.