### PR TITLE
Revert host.json to v1

### DIFF
--- a/host.json
+++ b/host.json
@@ -1,16 +1,11 @@
 {
-    "version": "2.0",
     "functionTimeout": "00:10:00",
-    "extensions": {
-        "eventHubs": {
-            "batchCheckpointFrequency": 1,
-            "eventProcessorOptions": {
-                "maxBatchSize": 64,
-                "prefetchCount": 128
-            }
-        }
+    "eventHub": {
+      "maxBatchSize": 64,
+      "prefetchCount": 256,
+      "batchCheckpointFrequency": 1
     },
     "tracing": {
-        "consoleLevel": "verbose"
+        "consoleLevel": "info"
     }
 }  


### PR DESCRIPTION
Use `host.json` v1 because function runtime uses `~1` version