### PR TITLE
Update function runtime to ~2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
+  - "8"
 install:
   - make deps
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
+  - "10"
 install:
   - make deps
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "10"
+  - "8"
+  - node
 install:
   - make deps
 script:

--- a/EHubGeneral/function.json
+++ b/EHubGeneral/function.json
@@ -4,7 +4,7 @@
       "type": "eventHubTrigger",
       "name": "eventHubMessages",
       "direction": "in",
-      "path": "%APP_LOG_EHUB_NAME%",
+      "eventHubName": "%APP_LOG_EHUB_NAME%",
       "connection": "APP_LOG_EHUB_CONNECTION",
       "cardinality": "many",
       "consumerGroup": "%APP_LOG_EHUB_CONSUMER_GROUP%"

--- a/extensions.csproj
+++ b/extensions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.*" />
+  </ItemGroup>
+</Project>

--- a/host.json
+++ b/host.json
@@ -10,7 +10,10 @@
             }
         }
     },
-    "tracing": {
-        "consoleLevel": "verbose"
+    "logging": {
+        "logLevel": {
+            "default": "Information"
+        }
     }
-}  
+}
+

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -139,7 +139,7 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "8.11.1"
+                            "value": "10.14.1"
                         },
                         {
                             "name": "APP_SUBSCRIPTION_ID",

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -119,7 +119,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~1"
+                            "value": "~2"
                         },
                         {
                             "name": "SCM_USE_FUNCPACK",
@@ -139,7 +139,7 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "6.5.0"
+                            "value": "8.11.1"
                         },
                         {
                             "name": "APP_SUBSCRIPTION_ID",


### PR DESCRIPTION
### Solution Description

Update function runtime to `~2`. This allows to update the node js version to `8.11.1`