### PR TITLE
Increase event hub trigger batch size

### DIFF
--- a/host.json
+++ b/host.json
@@ -5,8 +5,8 @@
         "eventHubs": {
             "batchCheckpointFrequency": 1,
             "eventProcessorOptions": {
-                "maxBatchSize": 64,
-                "prefetchCount": 128
+                "maxBatchSize": 512,
+                "prefetchCount": 1024
             }
         }
     },


### PR DESCRIPTION
Increase batch size to 512 to improve collection performance.