### PR TITLE
Update dependency

### DIFF
--- a/PostDeploymentActions/updateUpdaterTimer.ps1
+++ b/PostDeploymentActions/updateUpdaterTimer.ps1
@@ -1,6 +1,8 @@
+$randH = Get-Random -minimum 0 -maximum 11
 $randM = Get-Random -minimum 0 -maximum 59
 $randS = Get-Random -minimum 0 -maximum 59
-$new_schedule = "$randS $randM * * * *"
+$randH12 = $randH + 12
+$new_schedule = "$randS $randM $randH,$randH12 * * *"
 Write-Output "Updating Updater timer trigger with ($new_schedule)".
 $updater_function = Get-Content '..\\wwwroot\\Updater\\function.json' -raw | ConvertFrom-Json
 $updater_function.bindings | % {if($_.name -eq 'AlertlogicUpdaterTimer'){$_.schedule=$new_schedule}}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ehub-collector",
   "version": "1.2.0",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "^1.1.1",
+    "@alertlogic/al-azure-collector-js": "^1.1.2",
     "async": "^2.6.1",
     "moment": "^2.24.0",
     "parse-key-value": "^1.0.0"


### PR DESCRIPTION
Update `al-azure-collector-js`.
Revert  updater post deployment action to set updater timeout to up-to-12 hours. Meaning it could take from  0 up to 12 hours between consequent updates.