### PR TITLE
Dlblob error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nbproject/
 coverage/
 test/ide_test.js
 .env
+*.swp

--- a/common/ehub_collector.js
+++ b/common/ehub_collector.js
@@ -16,7 +16,7 @@ const defaultProcessError = function(context, err, messages) {
     context.log.error('Error processing batch:', err);
     const skipped = messages.records ? messages.records.length : messages.length;
     if (context.bindings.dlBlob && context.bindings.dlBlob instanceof Array) {
-        context.bindings.dlBlob.append([messages]);
+        context.bindings.dlBlob.push(messages);
     } else {
         context.bindings.dlBlob = [messages];
     }


### PR DESCRIPTION
This PR is to try and fix the `dlBlob.append is not a function` errors we're seeing in some collectors.

`append` is not a standard JS Array method, the method should be `push`.

I thought that the dlBlob context object had some sort of special methods when iw as doing my initial review of this. But on closer reading, it looks like its just an array. This should fix the error and make the DLblob an array of failed batches.