### PR TITLE
Add forced update functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "8"
   - node
 install:
-  - make deps
+  - npm install
 script:
-  - make test
+  - npm run test
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ehub-collector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "1.2.0",
+    "@alertlogic/al-azure-collector-js": "https://github.com/JDragovichAlertLogic/al-azure-collector-js.git#forced-update",
     "@alertlogic/al-collector-js": "1.3.0",
     "async": "2.6.1",
     "moment": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ehub-collector",
   "version": "1.3.1",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "https://github.com/JDragovichAlertLogic/al-azure-collector-js.git#forced-update",
+    "@alertlogic/al-azure-collector-js": "1.3.0",
     "@alertlogic/al-collector-js": "1.3.0",
     "async": "2.6.1",
     "moment": "2.24.0",


### PR DESCRIPTION
This PR updates the dependency for al-azure-collector-js library.

This will add the ability for alert logic to tell collectors to update themselves at checkin, rather that at the scheduled update time every 12 hours.