### PR TITLE
Release batching fixes

### DIFF
--- a/common/ehub_collector.js
+++ b/common/ehub_collector.js
@@ -42,12 +42,13 @@ module.exports = function (context, eventHubMessages, parseFun, processErrorFun,
                         if (err) {
                             const skipped =  processError(context, err, redResult);
                             context.log.error(`Error while processing records. Skipped ${skipped} Records`);
-                            return callback(err);
+                            context.log.error(`Error: ${err}`);
+                            return callback(null, { processed: 0, skipped });
                         } else {
                             const processed = redResult.length;
                             context.log.info(`Processed: ${processed}`);
                         }
-                        return callback(null, { processed: redResult, skipped: 0 });
+                        return callback(null, { processed: redResult.length, skipped: 0 });
                 });
             } catch (exception) {
                 const skipped = processError(context, exception, redResult);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehub-collector",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "@alertlogic/al-azure-collector-js": "2.0.0",
     "@alertlogic/al-collector-js": "1.3.2",

--- a/test/ehub_collector_test.js
+++ b/test/ehub_collector_test.js
@@ -102,8 +102,9 @@ describe('Common Event hub collector unit tests.', function() {
                 function fakeFn(messages, formatFun, hostmetaElems, callback) {
                     return callback({statusCode: 400});
                 });
-        ehubCollector(mockContext, testMessage, ehubGeneralFormat.logRecord , null, function(err) {
-            assert.equal(err.statusCode, 400);
+        ehubCollector(mockContext, testMessage, ehubGeneralFormat.logRecord , null, function(err, res) {
+            assert.equal(err, null);
+            assert.equal(res.skipped, 1);
             console.log(mockContext.bindings.dlBlob, typeof mockContext.bindings.dlBlob);
             assert.equal(mockContext.bindings.dlBlob, 'No blob records');
             sinon.assert.callCount(processLogStub, 1);

--- a/test/healthcheck_test.js
+++ b/test/healthcheck_test.js
@@ -168,7 +168,7 @@ describe('Event hub health check unit tests.', function() {
         ehubHealthCheck.eventHubNs(master, function(err) {
             assert.equal(err.status, 'error');
             assert.equal(err.error_code, 'EHUB000003');
-            let details = JSON.parse(err.details[0])
+            let details = JSON.parse(err.details[0]);
             assert.equal(details.statusCode, 404);
             done();
         });
@@ -195,7 +195,7 @@ describe('Event hub health check unit tests.', function() {
         ehubHealthCheck.eventHubNs(master, function(err) {
             assert.equal(err.status, 'error');
             assert.equal(err.error_code, 'EHUB000004');
-            let details = JSON.parse(err.details[0])
+            let details = JSON.parse(err.details[0]);
             assert.equal(details.statusCode, 404);
             done();
         });


### PR DESCRIPTION
This release should fix the issue of sending numerous ingest requests per invocation.

Now the collector aggregates all of the logs received in one invocation and sends them to ingest in one request. 

This should increase performance in high volume collectors.