### PR TITLE
update al-azure-collector to 2.1.0, DLQ sampels

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ehub-collector",
   "version": "1.4.1",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "2.0.0",
+    "@alertlogic/al-azure-collector-js": "2.1.0",
     "@alertlogic/al-collector-js": "1.3.2",
     "@azure/arm-eventhub": "3.2.0",
     "@azure/arm-monitor": "6.0.0",


### PR DESCRIPTION
This implements the dlq sample functionality for the ehub collector. This will be rolled back when the dlq samples are collected.