### PR TITLE
Handle Non-json Logs

### DIFF
--- a/EHubGeneral/function.json
+++ b/EHubGeneral/function.json
@@ -6,6 +6,7 @@
       "direction": "in",
       "eventHubName": "%APP_LOG_EHUB_NAME%",
       "connection": "APP_LOG_EHUB_CONNECTION",
+      "dataType": "string",
       "cardinality": "many",
       "consumerGroup": "%APP_LOG_EHUB_CONSUMER_GROUP%"
     },


### PR DESCRIPTION
This PR reconfigure the event hub collector to accept logs as strings, and attempts to parse them as JSON.