### PR TITLE
reduce error sampling to maximum 10 messages

### DIFF
--- a/DLBlob/index.js
+++ b/DLBlob/index.js
@@ -36,8 +36,10 @@ function processBlob(context, blob, dlblobText, callback) {
             break;
     }
     
+    const dlBlobMessages = getDlBlobMessages(dlblobText);
+
     try {
-        ehubCollector(context, JSON.parse(dlblobText), formatFun, processErrorFun, function(error, result) {
+        ehubCollector(context, dlBlobMessages, formatFun, processErrorFun, function(error, result) {
             if (result.skipped) {
                 return callback(`Unprocessed records: ${result.skipped}`);
             } else {
@@ -47,6 +49,16 @@ function processBlob(context, blob, dlblobText, callback) {
     } catch (ex) {
         return callback(ex);
     }
+}
+
+function getDlBlobMessages(dlblobText) {
+    const parsedBlob = JSON.parse(dlblobText);
+
+    if (parsedBlob.errorSample) {
+        return parsedBlob.messages;
+    } else {
+        return parsedBlob;
+    } 
 }
 
 module.exports = function (context, AlertlogicDLBlobTimer) {

--- a/DLBlob/index.js
+++ b/DLBlob/index.js
@@ -55,8 +55,15 @@ function getDlBlobMessages(dlblobText) {
     const parsedBlob = JSON.parse(dlblobText);
 
     if (Array.isArray(parsedBlob) && parsedBlob[0].errorSample) {
-        return parsedBlob[0].messages;
-    } else {
+        var blobMessages = parsedBlob[0].messages;
+        if (blobMessages.length < 10){
+            return blobMessages;
+        } 
+        else {
+            return blobMessages.slice(1, 10);
+        }
+    } 
+    else {
         return parsedBlob;
     } 
 }
@@ -82,4 +89,3 @@ module.exports = function (context, AlertlogicDLBlobTimer) {
         }
     });
 };
-

--- a/DLBlob/index.js
+++ b/DLBlob/index.js
@@ -15,6 +15,8 @@ const AlAzureDlBlob = require('@alertlogic/al-azure-collector-js').AlAzureDlBlob
 const ehubCollector = require('../common/ehub_collector');
 const ehubGeneralFormat = require('../EHubGeneral/format').logRecord;
 
+const MAX_AMOUNT_OF_DL_MESSAGES = 3;
+
 function getCollectorFunName(blobName) {
     return blobName.split('/')[1];
 }
@@ -56,14 +58,14 @@ function getDlBlobMessages(dlblobText) {
 
     if (Array.isArray(parsedBlob) && parsedBlob[0].errorSample) {
         var blobMessages = parsedBlob[0].messages;
-        if (blobMessages.length < 10){
+        if (blobMessages.length <= MAX_AMOUNT_OF_DL_MESSAGES){
             return blobMessages;
         } 
         else {
-            return blobMessages.slice(1, 10);
+            return blobMessages.slice(0, MAX_AMOUNT_OF_DL_MESSAGES);
         }
     } 
-    else {
+    else {  
         return parsedBlob;
     } 
 }

--- a/DLBlob/index.js
+++ b/DLBlob/index.js
@@ -54,8 +54,8 @@ function processBlob(context, blob, dlblobText, callback) {
 function getDlBlobMessages(dlblobText) {
     const parsedBlob = JSON.parse(dlblobText);
 
-    if (parsedBlob.errorSample) {
-        return parsedBlob.messages;
+    if (Array.isArray(parsedBlob) && parsedBlob[0].errorSample) {
+        return parsedBlob[0].messages;
     } else {
         return parsedBlob;
     } 

--- a/EHubGeneral/function.json
+++ b/EHubGeneral/function.json
@@ -6,6 +6,7 @@
       "direction": "in",
       "eventHubName": "%APP_LOG_EHUB_NAME%",
       "connection": "APP_LOG_EHUB_CONNECTION",
+      "dataType": "string",
       "cardinality": "many",
       "consumerGroup": "%APP_LOG_EHUB_CONSUMER_GROUP%"
     },

--- a/common/ehub_collector.js
+++ b/common/ehub_collector.js
@@ -15,15 +15,20 @@ const AlAzureCollector = require('@alertlogic/al-azure-collector-js').AlAzureCol
 const defaultProcessError = function(context, err, messages) {
     context.log.error('Error processing batch:', err);
     const skipped = messages.length;
+    const errorSample = {
+        type: 'errorSample',
+        errorMessage: err.message,
+        erroCode: err.statusCode
+    };
     // We're going to ignore 400s from ingest right now. Do not put them in the DLQ
     if(err.statusCode >= 400 && err.statusCode < 500){
         return skipped;
     }
     // Otherwise, we need to put them in the DLQ
     else if (context.bindings.dlBlob && context.bindings.dlBlob instanceof Array) {
-        context.bindings.dlBlob.push(messages);
+        context.bindings.dlBlob.push({errorSample, messages});
     } else {
-        context.bindings.dlBlob = [messages];
+        context.bindings.dlBlob = [{errorSample, messages}];
     }
     return skipped;
 };


### PR DESCRIPTION
Since https://github.com/alertlogic/ehub-collector/pull/54 was merged, we have seen an increase in `request_entity_too_large` errors coming from ehub collectors. This leads to failed checkins, which results in degraded log collection.
To hopefully resolve this, this attempts to restrict the amount of error sample messages put into the DLQ