### PR TITLE
Reduce error sampling to maximum 3 messages

### DIFF
--- a/DLBlob/index.js
+++ b/DLBlob/index.js
@@ -55,8 +55,15 @@ function getDlBlobMessages(dlblobText) {
     const parsedBlob = JSON.parse(dlblobText);
 
     if (Array.isArray(parsedBlob) && parsedBlob[0].errorSample) {
-        return parsedBlob[0].messages;
-    } else {
+        var blobMessages = parsedBlob[0].messages;
+        if (blobMessages.length < 10){
+            return blobMessages;
+        } 
+        else {
+            return blobMessages.slice(1, 10);
+        }
+    } 
+    else {
         return parsedBlob;
     } 
 }
@@ -82,4 +89,3 @@ module.exports = function (context, AlertlogicDLBlobTimer) {
         }
     });
 };
-

--- a/DLBlob/index.js
+++ b/DLBlob/index.js
@@ -15,6 +15,8 @@ const AlAzureDlBlob = require('@alertlogic/al-azure-collector-js').AlAzureDlBlob
 const ehubCollector = require('../common/ehub_collector');
 const ehubGeneralFormat = require('../EHubGeneral/format').logRecord;
 
+const MAX_AMOUNT_OF_DL_MESSAGES = 3;
+
 function getCollectorFunName(blobName) {
     return blobName.split('/')[1];
 }
@@ -56,14 +58,14 @@ function getDlBlobMessages(dlblobText) {
 
     if (Array.isArray(parsedBlob) && parsedBlob[0].errorSample) {
         var blobMessages = parsedBlob[0].messages;
-        if (blobMessages.length < 10){
+        if (blobMessages.length <= MAX_AMOUNT_OF_DL_MESSAGES){
             return blobMessages;
         } 
         else {
-            return blobMessages.slice(1, 10);
+            return blobMessages.slice(0, MAX_AMOUNT_OF_DL_MESSAGES);
         }
     } 
-    else {
+    else {  
         return parsedBlob;
     } 
 }


### PR DESCRIPTION
Since https://github.com/alertlogic/ehub-collector/pull/54 was merged, we have seen an increase in `request_entity_too_large` errors coming from ehub collectors. This leads to failed checkins, which results in degraded log collection.
To hopefully resolve this, this attempts to restrict the amount of error sample messages put into the DLQ