### PR TITLE
Added functionApp security changes

### DIFF
--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -163,15 +163,15 @@
                     "ftpsState": "FtpsOnly"
                 },
                 "clientAffinityEnabled": false,
-                "httpsOnly": true,
-                "clientCertEnabled": true,
-                "clientCertMode": "Required"
+                "httpsOnly": true,
+                "clientCertEnabled": true,
+                "clientCertMode": "Required"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName'))]"
             ],
             "resources": [
-                  {
+                {
                     "type": "Microsoft.Web/sites/config",
                     "apiVersion": "2018-02-01",
                     "name": "[concat(parameters('Application Name'), '/authsettings')]",

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -159,14 +159,32 @@
                             "type": "Custom",
                             "connectionString": "[parameters('Alert Logic Data Residency')]"
                         }
-                    ]
+                    ],
+                    "ftpsState": "FtpsOnly"
                 },
-                "clientAffinityEnabled": false
+                "clientAffinityEnabled": false,
+                "httpsOnly": true,
+                "clientCertEnabled": true,
+                "clientCertMode": "Required"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName'))]"
             ],
             "resources": [
+                  {
+                    "type": "Microsoft.Web/sites/config",
+                    "apiVersion": "2018-02-01",
+                    "name": "[concat(parameters('Application Name'), '/authsettings')]",
+                    "location": "[resourceGroup().location]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/sites', parameters('Application Name'))]"
+                    ],
+                    "properties": {
+                        "enabled": true,
+                        "unauthenticatedClientAction": "RedirectToLoginPage",
+                        "tokenStoreEnabled": true
+                    }
+                },
                 {
                     "apiVersion": "2018-02-01",
                     "name": "[variables('webAppSourceControlName')]",


### PR DESCRIPTION
ZENDESK-396012 : Increase Security / Compliance on EventHub Collector Deployments

FTPS should be required on the FunctionApp
FunctionApp should only be accessible over HTTPS
FunctionApps should have client certificates (Incoming client certificates) enabled
Authentication should be enabled on the FunctionApp

Enabled above settings.