### PR TITLE
Specify only the major nodejs version in template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ nbproject/
 coverage/
 test/ide_test.js
 .env
+local_dev/dev_config.js
+.log
 *.swp

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -176,7 +176,7 @@
                             "connectionString": "[parameters('Alert Logic Data Residency')]"
                         }
                     ],
-                    "ftpsState": "FtpsOnly"
+                    "ftpsState": "FtpsOnly"
                 },
                 "clientAffinityEnabled": false,
                 "httpsOnly": true,
@@ -228,7 +228,7 @@
                         "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName')), '2015-06-15').key1)]",
                         "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName')), '2015-06-15').key1)]",
                         "WEBSITE_CONTENTSHARE": "[concat(toLower(parameters('Application Name')), '9546')]",
-                        "WEBSITE_NODE_DEFAULT_VERSION": "12.13.0",
+                        "WEBSITE_NODE_DEFAULT_VERSION": "~12",
                         "FUNCTIONS_EXTENSION_VERSION": "~3",
                         "SCM_USE_FUNCPACK": "1",
                         "SCM_POST_DEPLOYMENT_ACTIONS_PATH": "PostDeploymentActions",


### PR DESCRIPTION
### Problem
The template specifies `12.13.0` nodejs version which is no longer available on Azure runtime `3.3.1.0`.

### Solution
- Update the template to use the latest `12.*` nodejs runtime available
- Also remove the non-breaking space from the template