### PR TITLE
Use variables for runtime version in template

### DIFF
--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -94,6 +94,8 @@
         "createNewEhubInfraCond": "[if(and(equals(parameters('Event Hub Resource Group'), ''), equals(parameters('Event Hub Connection String'), ''), equals(parameters('Event Hub Namespace'), '')), bool('true'), bool('false'))]",
         "repo": "https://github.com/alertlogic/ehub-collector.git",
         "branch": "v1",
+        "nodeRuntimeVersion": "~12",
+        "azureFunctionExtensionsVersion": "~3",
         "dlContainerName": "alertlogic-dl",
         "statsQueueName": "alertlogic-stats",
         "newEhubMaxThroughputUnits": 20,
@@ -131,7 +133,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "[variables('azureFunctionExtensionsVersion')]"
                         },
                         {
                             "name": "SCM_USE_FUNCPACK",
@@ -151,7 +153,7 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "12.13.0"
+                            "value": "[variables('nodeRuntimeVersion')]"
                         }
                     ],
                     "connectionStrings": [
@@ -228,8 +230,8 @@
                         "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName')), '2015-06-15').key1)]",
                         "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('webAppStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('webAppStorageAccountName')), '2015-06-15').key1)]",
                         "WEBSITE_CONTENTSHARE": "[concat(toLower(parameters('Application Name')), '9546')]",
-                        "WEBSITE_NODE_DEFAULT_VERSION": "~12",
-                        "FUNCTIONS_EXTENSION_VERSION": "~3",
+                        "WEBSITE_NODE_DEFAULT_VERSION": "[variables('nodeRuntimeVersion')]",
+                        "FUNCTIONS_EXTENSION_VERSION": "[variables('azureFunctionExtensionsVersion')]",
                         "SCM_USE_FUNCPACK": "1",
                         "SCM_POST_DEPLOYMENT_ACTIONS_PATH": "PostDeploymentActions",
                         "APP_SUBSCRIPTION_ID": "[variables('subscriptionId')]",


### PR DESCRIPTION
### Problem
Sourcecontrol fails to create because it tries to use an ancient nodejs version in the absence of 12.13.0:
>npm ERR! Error: Method Not Allowed
npm ERR!     at errorResponse (C:\Program Files (x86)\npm\1.4.28\node_modules\npm\lib\cache\add-named.js:260:10)
npm ERR!     at C:\Program Files (x86)\npm\1.4.28\node_modules\npm\lib\cache\add-named.js:120:12
An error has occurred during web site deployment.
npm ERR!     at saved (C:\Program Files (x86)\npm\1.4.28\node_modules\npm\node_modules\npm-registry-client\lib\get.js:167:7)
npm ERR!     at Object.oncomplete (fs.js:108:15)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>
npm ERR! System Windows_NT 6.2.9200
npm ERR! command "node" "C:\\Program Files (x86)\\npm\\1.4.28\\node_modules\\npm\\bin\\npm-cli.js" "install" "--production"
npm ERR! cwd C:\home\site\wwwroot
npm ERR! node -v v0.10.40
npm ERR! npm -v 1.4.28
npm ERR! code E405

### Solution
Use variables in the template to avoid defining the runtime version twice