### PR TITLE
Checkin failed with error invalid_input, body error in azcollect when sockets exhaust in azure function app while using application insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ehub-collector",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "3.1.3",
+    "@alertlogic/al-azure-collector-js": "3.1.4",
     "@alertlogic/al-collector-js": "3.0.9",
     "@azure/arm-eventhub": "3.3.1",
     "@azure/arm-monitor": "6.1.1",


### PR DESCRIPTION
### Problem Description
 Checkin failed with error invalid_input, body error in azcollect when sockets exhaust in azure function app while using application insights .
 the below error 
 Statistics retrieval failed with An error occurred, while getting application insights appId AggregateAuthenticationError: ChainedTokenCredential authentication failed.
CredentialUnavailableError: EnvironmentCredential is unavailable. No underlying credential could be used. To troubleshoot, visit https://aka.ms/azsdk/js/identity/environmentcredential/troubleshoot.
CredentialUnavailableError: WorkloadIdentityCredential: is unavailable. tenantId, clientId, and federatedTokenFilePath are required parameters. 
  Still, this doesn’t address the root cause of the issue which is the intermittent EACCES errors.
### Solution Description
Fixed Checkin failed with error invalid_input, body error in application statistics code  by adding **statistics** field which was not send to checkin payload because of sockets exhaust listing of resource group called failed.

 