### PR TITLE
[Prod-Ehub]Moved calling of Eventhub Management client to global space and bumped al-azure-collector to 3.1.6 and al-collector-js to 3.0.14 

### DIFF
--- a/Master/healthcheck.js
+++ b/Master/healthcheck.js
@@ -62,8 +62,12 @@ function checkEventHub(master, eventHubs, callback) {
     }
 }
 
+function initArmEhub(master) {
+    return ehubUtil.initArmEhub(master);
+}
+
 const eventHubNs = function(master, callback) {
-    var armEhub = ehubUtil.initArmEhub(master);
+    var armEhub = initArmEhub(master);
     const rg = ehubUtil.getEhubForLogResourceGroup(master);
     const nsName = ehubUtil.getEhubNsName();
     

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ehub-collector",
-  "version": "1.6.15",
+  "version": "1.6.16",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "3.1.5",
-    "@alertlogic/al-collector-js": "3.0.11",
+    "@alertlogic/al-azure-collector-js": "3.1.6",
+    "@alertlogic/al-collector-js": "3.0.14",
     "@azure/arm-eventhub": "3.3.1",
     "@azure/arm-monitor": "6.1.1",
     "async": "^3.2.5",


### PR DESCRIPTION
Refer pr https://github.com/alertlogic/al-collector-js/pull/63 for httpagent fixes.
Moved calling of Eventhub Management client to global space.