### PR TITLE
Added minimulTLSVersion parameter for functionapp,storage and eventhub

### DIFF
--- a/common/ehub_collector.js
+++ b/common/ehub_collector.js
@@ -18,10 +18,10 @@ const defaultProcessError = function(context, err, messages) {
     const errorSample = {
         type: 'errorSample',
         errorMessage: err.message,
-        erroCode: err.statusCode
+        erroCode: err.statusCode || err.status 
     };
     // We're going to ignore 400s from ingest right now. Do not put them in the DLQ
-    if(err.statusCode >= 400 && err.statusCode < 500){
+    if((err.statusCode >= 400 && err.statusCode < 500) || (err.status >= 400 && err.status < 500) ){
         return skipped;
     }
     // Otherwise, we need to put them in the DLQ

--- a/common/util.js
+++ b/common/util.js
@@ -12,8 +12,7 @@ const {EventHubManagementClient} = require('@azure/arm-eventhub');
 const parse = require('parse-key-value');
 
 const DEFAULT_EHUB_FOR_LOG_NAME = 'alertlogic-log';
-
-
+let eventHubClient = null;
 const initArmMonitor = function(master) {
     const azureCreds = master.getApplicationTokenCredentials();
     const subscriptionId = master.getConfigAttrs().subscription_id;
@@ -21,9 +20,12 @@ const initArmMonitor = function(master) {
 };
 
 const initArmEhub = function(master) {
-    const azureCreds = master.getApplicationTokenCredentials();
-    const subscriptionId = master.getConfigAttrs().subscription_id;
-    return new EventHubManagementClient(azureCreds, subscriptionId);
+    if (!eventHubClient) {
+        const azureCreds = master.getApplicationTokenCredentials();
+        const subscriptionId = master.getConfigAttrs().subscription_id;
+        eventHubClient = new EventHubManagementClient(azureCreds, subscriptionId);
+    }
+    return eventHubClient;
 };
 
 const formatSdkError = function (master, alErrorCode, message, err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehub-collector",
-  "version": "1.6.16",
+  "version": "1.6.17",
   "dependencies": {
     "@alertlogic/al-azure-collector-js": "3.1.6",
     "@alertlogic/al-collector-js": "3.0.14",

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -1,18 +1,18 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.1",
+    "contentVersion": "1.0.0.2",
     "parameters": {
         "Application Name": {
-            "type": "String"
+            "type": "string"
         },
         "Alert Logic Access Key ID": {
-            "type": "String"
+            "type": "string"
         },
         "Alert Logic Secret Key": {
-            "type": "SecureString"
+            "type": "securestring"
         },
         "Alert Logic API endpoint": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "api.global-services.global.alertlogic.com",
             "allowedValues" : [
                 "api.global-services.global.alertlogic.com",
@@ -20,35 +20,35 @@
             ]
         },
         "Alert Logic Data Residency": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "default",
             "allowedValues": [
                 "default"
             ]
         },
         "Event Hub Resource Group": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Specifies the resource group for existing event hub. Leave empty to install Alert Logic managed event hub infrastructure."
             }
         },
         "Event Hub Connection String": {
-            "type": "SecureString",
+            "type": "securestring",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Specifies the connection string for existing event hub. Leave empty if you use Alert Logic managed event hub infrastructure."
             }
         },
         "Event Hub Namespace": {
-            "type": "String",
+            "type": "securestring",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Specifies the namespace for existing event hub. Leave empty if you use Alert Logic managed event Hub infrastructure."
             }
         },
         "Event Hub Name": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "insights-operational-logs",
             "metadata": {
                 "description": "Please use the actual name if using existing event hub."
@@ -89,32 +89,43 @@
             }
         },
         "Event Hub Consumer Group": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "$Default",
             "metadata": {
                 "description": "Optional. Please use the actual consumer group if using existing event hub."
             }
         },
         "Event Hub Filter Json": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Please enter type of filter in JSON format. Only messages which contain the specified property will be collected.\n e.g {\"channels\": \"Operation\"}"
             }
         },
         "Event Hub Filter Regex": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Please enter type of filter in REGEX format. Only messages which contain the specified property will be collected.\n e.g ^channels.*"
             }
         },
         "enableApplicationInsights": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "No",
             "allowedValues":["Yes", "No"],
             "metadata": {
                 "description": "Enable Application Insights (Optional)."
+            }
+        },
+        "minimumTlsVersion": {
+            "type": "string",
+            "defaultValue": "1.2",
+            "allowedValues": [
+                "1.2",
+                "1.3"
+            ],
+            "metadata": {
+            "description": "The minimum TLS version to be used for Function App, Event Hub, and Storage Account."
             }
         }
     },
@@ -137,7 +148,7 @@
         "repo": "https://github.com/alertlogic/ehub-collector.git",
         "branch": "v1",
         "nodeRuntimeVersion": "~20",
-       "azureFunctionExtensionsVersion": "~4",
+        "azureFunctionExtensionsVersion": "~4",
         "dlContainerName": "alertlogic-dl",
         "statsQueueName": "alertlogic-stats",
         "newEhubMaxThroughputUnits": "[parameters('Event Hub Max Throughput Units')]",
@@ -147,7 +158,9 @@
         "filterJson": "[parameters('Event Hub Filter Json')]",
         "filterRegex": "[parameters('Event Hub Filter Regex')]",
         "isApplicationInsightEnabled": "[equals(parameters('enableApplicationInsights'),'Yes')]",
-        "applicationInsightsName":"[concat(parameters('Application Name'),'-',take(subscription().tenantId,5))]"
+        "applicationInsightsName": "[concat(parameters('Application Name'),'-',take(subscription().tenantId,5))]",
+        "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
+        "minimumTlsVersionForStorage": "[if(equals(parameters('minimumTlsVersion'), '1.3'), 'TLS1_3', 'TLS1_2')]"
     },
     "resources": [
         {
@@ -226,7 +239,8 @@
                             "connectionString": "[parameters('Alert Logic Data Residency')]"
                         }
                     ],
-                    "ftpsState": "FtpsOnly"
+                    "ftpsState": "FtpsOnly",
+                    "minTlsVersion": "[variables('minimumTlsVersion')]"
                 },
                 "clientAffinityEnabled": false,
                 "httpsOnly": true,
@@ -288,7 +302,7 @@
                         "APP_SUBSCRIPTION_ID": "[variables('subscriptionId')]",
                         "APP_RESOURCE_GROUP": "[variables('resourceGroupName')]",
                         "APP_TENANT_ID": "[variables('tenantId')]",
-                        "APP_LOG_EHUB_CONNECTION": "[if(equals(parameters('Event Hub Connection String'), ''), listKeys(resourceId('Microsoft.EventHub/namespaces/AuthorizationRules', variables('ehubNsName'), 'RootManageSharedAccessKey'), '2017-04-01').primaryConnectionString, parameters('Event Hub Connection String'))]",
+                        "APP_LOG_EHUB_CONNECTION": "[if(equals(parameters('Event Hub Connection String'), ''), listKeys(resourceId('Microsoft.EventHub/namespaces/AuthorizationRules', variables('ehubNsName'), 'RootManageSharedAccessKey'), '2024-01-01').primaryConnectionString, parameters('Event Hub Connection String'))]",
                         "APP_LOG_EHUB_NAME": "[variables('ehubName')]",
                         "APP_LOG_EHUB_CONSUMER_GROUP": "[variables('ehubConsumerGroup')]",
                         "APP_LOG_EHUB_RESOURCE_GROUP": "[variables('ehubResourceGroup')]",
@@ -328,7 +342,8 @@
             },
             "properties": {
                 "allowBlobPublicAccess": false,
-                "supportsHttpsTrafficOnly": true
+                "supportsHttpsTrafficOnly": true,
+                "minimumTlsVersion": "[variables('minimumTlsVersionForStorage')]"
             },
             "tags": {
                 "AlertLogicCollector": "[parameters('Application Name')]"
@@ -373,12 +388,13 @@
                 "capacity":"[variables('newEhubMaxThroughputUnits')]"
             },
             "name": "[variables('ehubNsName')]",
-            "apiVersion": "2017-04-01",
+            "apiVersion": "2024-01-01",
             "location": "[variables('location')]",
             "tags": {},
             "properties": {
                 "isAutoInflateEnabled": "[variables('newEhubAutoInflateEnabled')]",
-                "maximumThroughputUnits": "[variables('newEhubMaxThroughputUnits')]"
+                "maximumThroughputUnits": "[variables('newEhubMaxThroughputUnits')]",
+                "minimumTlsVersion": "[variables('minimumTlsVersion')]"
             },
             "dependsOn": [],
             "resources": [
@@ -386,7 +402,7 @@
                     "condition": "[variables('createNewEhubInfraCond')]",
                     "type": "eventhubs",
                     "name": "[variables('ehubName')]",
-                    "apiVersion": "2017-04-01",
+                    "apiVersion": "2024-01-01",
                     "location": "[variables('location')]",
                     "properties": {
                         "messageRetentionInDays": "[variables('newEhubRetentionDays')]",

--- a/templates/ehub_premium.json
+++ b/templates/ehub_premium.json
@@ -1,18 +1,18 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.1",
+    "contentVersion": "1.0.0.2",
     "parameters": {
         "Application Name": {
-            "type": "String"
+            "type": "string"
         },
         "Alert Logic Access Key ID": {
-            "type": "String"
+            "type": "string"
         },
         "Alert Logic Secret Key": {
-            "type": "SecureString"
+            "type": "securestring"
         },
         "Alert Logic API endpoint": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "api.global-services.global.alertlogic.com",
             "allowedValues" : [
                 "api.global-services.global.alertlogic.com",
@@ -20,70 +20,80 @@
             ]
         },
         "Alert Logic Data Residency": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "default",
             "allowedValues": [
                 "default"
             ]
         },
         "Event Hub Resource Group": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Specifies the resource group for existing event hub. Leave empty to install Alert Logic managed event hub infrastructure."
             }
         },
         "Event Hub Connection String": {
-            "type": "SecureString",
+            "type": "securestring",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Specifies the connection string for existing event hub. Leave empty if you use Alert Logic managed event hub infrastructure."
             }
         },
         "Event Hub Namespace": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Specifies the namespace for existing event hub. Leave empty if you use Alert Logic managed event Hub infrastructure."
             }
         },
         "Event Hub Name": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "insights-operational-logs",
             "metadata": {
                 "description": "Please use the actual name if using existing event hub."
             }
         },
         "Event Hub Consumer Group": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "$Default",
             "metadata": {
                 "description": "Please use the actual consumer group if using existing event hub."
             }
         },
         "Event Hub Filter Json": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Please enter type of filter in JSON format. Only messages which contain the specified property will be collected.\n e.g {\"channels\": \"Operation\"}"
             }
         },
         "Event Hub Filter Regex": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "Optional. Please enter type of filter in REGEX format. Only messages which contain the specified property will be collected.\n e.g ^channels.*"
             }
         },
         "enableApplicationInsights": {
-            "type": "String",
+            "type": "string",
             "defaultValue": "No",
             "allowedValues":["Yes", "No"],
             "metadata": {
                 "description": "Enable Application Insights (Optional)."
             }
         },
-
+        "minimumTlsVersion": {
+            "type": "string",
+            "defaultValue": "1.2",
+            "allowedValues": [
+                "1.2",
+                "1.3"
+            ],
+            "metadata": {
+            "description": "The minimum TLS version to be used for Function App, Event Hub, and Storage Account."
+            }
+        },
         "Event Hub Max Throughput Units": {
             "type": "int",
             "defaultValue": 20,
@@ -191,7 +201,7 @@
         "repo": "https://github.com/alertlogic/ehub-collector.git",
         "branch": "v1",
         "nodeRuntimeVersion": "~20",
-       "azureFunctionExtensionsVersion": "~4",
+        "azureFunctionExtensionsVersion": "~4",
         "dlContainerName": "alertlogic-dl",
         "statsQueueName": "alertlogic-stats",
         "newEhubMaxThroughputUnits": "[parameters('Event Hub Max Throughput Units')]",
@@ -201,6 +211,8 @@
         "filterJson": "[parameters('Event Hub Filter Json')]",
         "filterRegex": "[parameters('Event Hub Filter Regex')]",
         "isApplicationInsightEnabled": "[equals(parameters('enableApplicationInsights'),'Yes')]",
+        "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
+        "minimumTlsVersionForStorage": "[if(equals(parameters('minimumTlsVersion'), '1.3'), 'TLS1_3', 'TLS1_2')]",
         "applicationInsightsName":"[concat(parameters('Application Name'),'-',take(subscription().tenantId,5))]",
         "appServicePlanName": "[concat('AppServicePlan-', parameters('Application Name'))]",
         "privateStorageFileDnsZoneName": "[format('privatelink.file.{0}', environment().suffixes.storage)]",
@@ -226,6 +238,7 @@
                 "name": "[parameters('Application Name')]",
                 "siteConfig": {
                     "vnetRouteAllEnabled": true,
+                    "alwaysOn": true,
                     "appSettings": [
                         {
                             "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -298,7 +311,8 @@
                             "connectionString": "[parameters('Alert Logic Data Residency')]"
                         }
                     ],
-                    "ftpsState": "FtpsOnly"
+                    "ftpsState": "FtpsOnly",
+                    "minTlsVersion": "[variables('minimumTlsVersion')]"
                 },
                 "clientAffinityEnabled": false,
                 "httpsOnly": true,
@@ -366,7 +380,7 @@
                         "APP_SUBSCRIPTION_ID": "[variables('subscriptionId')]",
                         "APP_RESOURCE_GROUP": "[variables('resourceGroupName')]",
                         "APP_TENANT_ID": "[variables('tenantId')]",
-                        "APP_LOG_EHUB_CONNECTION": "[if(equals(parameters('Event Hub Connection String'), ''), listKeys(resourceId('Microsoft.EventHub/namespaces/AuthorizationRules', variables('ehubNsName'), 'RootManageSharedAccessKey'), '2017-04-01').primaryConnectionString, parameters('Event Hub Connection String'))]",
+                        "APP_LOG_EHUB_CONNECTION": "[if(equals(parameters('Event Hub Connection String'), ''), listKeys(resourceId('Microsoft.EventHub/namespaces/AuthorizationRules', variables('ehubNsName'), 'RootManageSharedAccessKey'), '2024-01-01').primaryConnectionString, parameters('Event Hub Connection String'))]",
                         "APP_LOG_EHUB_NAME": "[variables('ehubName')]",
                         "APP_LOG_EHUB_CONSUMER_GROUP": "[variables('ehubConsumerGroup')]",
                         "APP_LOG_EHUB_RESOURCE_GROUP": "[variables('ehubResourceGroup')]",
@@ -729,7 +743,8 @@
             "properties": {
                 "allowBlobPublicAccess": false,
                 "supportsHttpsTrafficOnly": true,
-                 "publicNetworkAccess": "Enabled",
+                "minimumTlsVersion": "[variables('minimumTlsVersionForStorage')]",
+                "publicNetworkAccess": "Enabled",
                 "networkAcls": {
                     "bypass": "None",
                     "defaultAction": "Deny"
@@ -785,12 +800,13 @@
                 "capacity":"[variables('newEhubMaxThroughputUnits')]"
             },
             "name": "[variables('ehubNsName')]",
-            "apiVersion": "2017-04-01",
+            "apiVersion":"2024-01-01",
             "location": "[variables('location')]",
             "tags": {},
             "properties": {
                 "isAutoInflateEnabled": "[variables('newEhubAutoInflateEnabled')]",
-                "maximumThroughputUnits": "[variables('newEhubMaxThroughputUnits')]"
+                "maximumThroughputUnits": "[variables('newEhubMaxThroughputUnits')]",
+                "minimumTlsVersion": "[variables('minimumTlsVersion')]"
             },
             "dependsOn": [],
             "resources": [
@@ -798,7 +814,7 @@
                     "condition": "[variables('createNewEhubInfraCond')]",
                     "type": "eventhubs",
                     "name": "[variables('ehubName')]",
-                    "apiVersion": "2017-04-01",
+                    "apiVersion": "2024-01-01",
                     "location": "[variables('location')]",
                     "properties": {
                         "messageRetentionInDays": "[variables('newEhubRetentionDays')]",


### PR DESCRIPTION
### Problem Description
Azure are deprecating support for TLS 1.1 and older so we need to make sure we update  our ARM templates to 1.2 or later
### Solution Description

1. Added options in parameters to select TLS version 1.2 or later for function app,storage accounts and eventhub. 
2. Updated eventhub api version from "apiVersion": "2017-04-01" to "apiVersion":"2024-01-01" for TLS support.
3. Modified the EventHub Management client logic to return the existing client if it has already been created; otherwise, create and return a new client and error handling issues.