### PR TITLE
[Prod-Ehub]Upgrade from node 20 to 22 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Use below premium function ARM template.
 
 3.  If you are using the [Premium plan ARM template page](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Falertlogic%2Fehub-collector%2Fv1%2Ftemplates%2Fehub_premium.json) in Azure, provide the following additional required template parameters.
 
-	  - **AppService Plan SKU Name** - Select App service plan options for Elastic premium (EP1, EP2 or EP3) from the dropdown.
-    - **Vnet Name** - Type the name of the virtual network for virtual network integration. The default value is [format('vnet-{0}', uniqueString(resourceGroup().id))].
+	 - **AppService Plan SKU Name** - Select App service plan options for Elastic premium (EP1, EP2 or EP3) from the dropdown.
+    - **Vnet Name** - Type the name of the virtual network for virtual network integration. The default value is al-function-vnet.
     - **Function Subnet Name** -Type the name of the virtual network subnet to be associated with the Azure Function app. The default value is (al-function-subnet).
     - **Private Endpoint Subnet Name** - Type the name of the virtual network subnet used for allocating IP addresses for private endpoints. The default value is (al-privateendpoint-subnet).
     - **Vnet Address Prefix** - Type the IP address space used for the virtual network. The default value is (10.100.0.0/16).

--- a/al-ehub-collector.json
+++ b/al-ehub-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "FUNCTIONS_EXTENSION_VERSION": "~4",
-        "WEBSITE_NODE_DEFAULT_VERSION": "~20"
+        "WEBSITE_NODE_DEFAULT_VERSION": "~22"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ehub-collector",
-  "version": "1.6.18",
+  "version": "1.6.19",
   "dependencies": {
-    "@alertlogic/al-azure-collector-js": "3.1.8",
-    "@alertlogic/al-collector-js": "3.0.14",
+    "@alertlogic/al-azure-collector-js": "3.1.9",
+    "@alertlogic/al-collector-js": "3.0.17",
     "@azure/arm-eventhub": "3.3.1",
     "@azure/arm-monitor": "6.1.1",
     "async": "^3.2.5",

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - make test
@@ -16,7 +16,7 @@ stages:
         name: V1 Push - Coverage
         when:
             - push: ['v1']
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - make test

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -147,7 +147,7 @@
         "createNewEhubInfraCond": "[if(and(equals(parameters('Event Hub Resource Group'), ''), equals(parameters('Event Hub Connection String'), ''), equals(parameters('Event Hub Namespace'), '')), bool('true'), bool('false'))]",
         "repo": "https://github.com/alertlogic/ehub-collector.git",
         "branch": "v1",
-        "nodeRuntimeVersion": "~20",
+        "nodeRuntimeVersion": "~22",
         "azureFunctionExtensionsVersion": "~4",
         "dlContainerName": "alertlogic-dl",
         "statsQueueName": "alertlogic-stats",

--- a/templates/ehub_premium.json
+++ b/templates/ehub_premium.json
@@ -139,9 +139,9 @@
           },
         "vnetName": {
             "type": "string",
-            "defaultValue": "[format('vnet-{0}', uniqueString(resourceGroup().id))]",
+            "defaultValue": "al-function-vnet",
             "metadata": {
-                "description": "The name of the virtual network for virtual network integration."
+                "description": "The name of the virtual network for function app virtual network integration."
             }
         },
         "functionSubnetName": {
@@ -200,7 +200,7 @@
         "createNewEhubInfraCond": "[if(and(equals(parameters('Event Hub Resource Group'), ''), equals(parameters('Event Hub Connection String'), ''), equals(parameters('Event Hub Namespace'), '')), bool('true'), bool('false'))]",
         "repo": "https://github.com/alertlogic/ehub-collector.git",
         "branch": "v1",
-        "nodeRuntimeVersion": "~20",
+        "nodeRuntimeVersion": "~22",
         "azureFunctionExtensionsVersion": "~4",
         "dlContainerName": "alertlogic-dl",
         "statsQueueName": "alertlogic-stats",


### PR DESCRIPTION
### Problem Description
Upgraded the Node.js runtime version for Azure Functions from 20 to 22.
Change the default VNet name from [format('vnet-{0}', uniqueString(resourceGroup().id))] to al-function-vnet for clarity and consistency.

### Solution Description
Updated the nodeRuntimeVersion variable in ARM templates and any related deployment scripts to use ~22 instead of ~20.
The default VNet name parameter remains unchanged: "defaultValue": "al-function-vnet".
Refer https://github.com/alertlogic/al-azure-collector-js/pull/51