### PR TITLE
 Update the Event Hub Collector Consumption plan ARM template (ehub.json) to use General Purpose Storage Account V2 and deprecate V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Use below premium function ARM template.
 
    **Note:** For "Event Hub Filter Json" and "Event Hub Filter Regex", only messages which contain the specified property will be collected. If both the filter values are provided then logs will be collected based on both the values.
    - **Enable Application Insights** - Enable or Disable Application Insights (Optional) for monitoring invocation logs. Default value is No. Follow this guide to monitor azure functions  [click here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-monitoring).
+   - **Storage Account Type** - The storage account kind. `V2` maps to Azure `StorageV2` and is the recommended option with Hot tier. `V1 (deprecated)` maps to Azure `Storage` and will be auto-migrated by Microsoft to `StorageV2` by October 2026.
 
 3.  If you are using the [Premium plan ARM template page](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Falertlogic%2Fehub-collector%2Fv1%2Ftemplates%2Fehub_premium.json) in Azure, provide the following additional required template parameters.
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ehub-collector",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "dependencies": {
     "@alertlogic/al-azure-collector-js": "3.1.9",
-    "@alertlogic/al-collector-js": "3.0.17",
+    "@alertlogic/al-collector-js": "3.0.20",
     "@azure/arm-eventhub": "3.3.1",
     "@azure/arm-monitor": "6.1.1",
     "async": "^3.2.5",

--- a/templates/ehub.json
+++ b/templates/ehub.json
@@ -127,6 +127,17 @@
             "metadata": {
             "description": "The minimum TLS version to be used for Function App, Event Hub, and Storage Account."
             }
+        },
+        "Storage Account Type": {
+            "type": "string",
+            "defaultValue": "V2",
+            "allowedValues": [
+                "V2",
+                "V1 (deprecated)"
+            ],
+            "metadata": {
+                "description": "The storage account kind. V2 maps to Azure StorageV2 and is the recommended option with Hot tier. V1 (deprecated) maps to Azure Storage and will be auto-migrated by Microsoft to StorageV2 by October 2026."
+            }
         }
     },
     "variables": {
@@ -160,7 +171,8 @@
         "isApplicationInsightEnabled": "[equals(parameters('enableApplicationInsights'),'Yes')]",
         "applicationInsightsName": "[concat(parameters('Application Name'),'-',take(subscription().tenantId,5))]",
         "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
-        "minimumTlsVersionForStorage": "[if(equals(parameters('minimumTlsVersion'), '1.3'), 'TLS1_3', 'TLS1_2')]"
+        "minimumTlsVersionForStorage": "[if(equals(parameters('minimumTlsVersion'), '1.3'), 'TLS1_3', 'TLS1_2')]",
+        "storageAccountType": "[if(equals(parameters('Storage Account Type'), 'V1 (deprecated)'), 'Storage', 'StorageV2')]"
     },
     "resources": [
         {
@@ -335,7 +347,7 @@
             "name": "[variables('webAppStorageAccountName')]",
             "apiVersion": "2019-06-01",
             "location": "[variables('location')]",
-            "kind": "Storage",
+            "kind": "[variables('storageAccountType')]",
             "sku": {
                 "name": "Standard_LRS",
                 "tier": "Standard"
@@ -343,7 +355,8 @@
             "properties": {
                 "allowBlobPublicAccess": false,
                 "supportsHttpsTrafficOnly": true,
-                "minimumTlsVersion": "[variables('minimumTlsVersionForStorage')]"
+                "minimumTlsVersion": "[variables('minimumTlsVersionForStorage')]",
+                "accessTier": "Hot"
             },
             "tags": {
                 "AlertLogicCollector": "[parameters('Application Name')]"


### PR DESCRIPTION
### Problem Description

- Microsoft retired GPv1 storage account creation on March 3, 2026
- Existing GPv1 accounts will be automatically migrated to GPv2 by October 2026
- GPv2 provides better performance, security, and pricing flexibility
- Premium plan template (ehub_premium.json) has already been updated to StorageV2

### Solution Description

- Added a new Storage Account Type parameter with options `V2` and` V1 (deprecated)`.
- Set the default to `V2`, and updated the storage account kind to be set through a mapped variable.
- Mapping behavior:
- `V2` maps to` StorageV2` kind (recommended, Hot tier)
- `V1 (deprecated)` maps `Storage`kind (Microsoft auto-migrates to `StorageV2` by October 2026)
- Updated README and template help metadata to document the new parameter and mapping.
- New deployments use `V2` by default, so no customer action is required.

